### PR TITLE
Add {ReadOnly}Span APIs 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.100
+    - name: Build
+      run: dotnet build --configuration Release
+    - name: Test
+      run: dotnet test --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,13 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+# vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+.ionide/
+.history/

--- a/CSharp.Ulid.Tests/CSharp.Ulid.Tests.csproj
+++ b/CSharp.Ulid.Tests/CSharp.Ulid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CSharp.Ulid/CSharp.Ulid.csproj
+++ b/CSharp.Ulid/CSharp.Ulid.csproj
@@ -1,7 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
 
 </Project>

--- a/CSharp.Ulid/Ulid.cs
+++ b/CSharp.Ulid/Ulid.cs
@@ -84,7 +84,7 @@ namespace CSharp.Ulid
                 throw new ArgumentException($"Expected a length of {TIMESTAMP_LENGTH}, received {timestamp.Length}", nameof(timestamp));
             }
 
-            if(randomness.Length != RANDOMNESS_LENGTH)
+            if (randomness.Length != RANDOMNESS_LENGTH)
             {
                 throw new ArgumentException($"Expected a length of {RANDOMNESS_LENGTH}, received {randomness.Length}", nameof(randomness));
             }
@@ -108,6 +108,9 @@ namespace CSharp.Ulid
         }
 
         public Ulid(byte[] data)
+            : this(new ReadOnlySpan<byte>(data)) { }
+
+        public Ulid(ReadOnlySpan<byte> data)
         {
             const int DATA_LENGTH = 16;
 
@@ -327,25 +330,36 @@ namespace CSharp.Ulid
 
         public byte[] ToByteArray()
         {
-            return new byte[]
+            var destination = new byte[16];
+            TryWriteBytes(destination);
+            return destination;
+        }
+
+        public bool TryWriteBytes(Span<byte> destination)
+        {
+            if (destination.Length < 16)
             {
-                this.TimeStamp_0,
-                this.TimeStamp_1,
-                this.TimeStamp_2,
-                this.TimeStamp_3,
-                this.TimeStamp_4,
-                this.TimeStamp_5,
-                this.Randomness_0,
-                this.Randomness_1,
-                this.Randomness_2,
-                this.Randomness_3,
-                this.Randomness_4,
-                this.Randomness_5,
-                this.Randomness_6,
-                this.Randomness_7,
-                this.Randomness_8,
-                this.Randomness_9,
-            };
+                return false;
+            }
+
+            destination[0] = TimeStamp_0;
+            destination[1] = TimeStamp_1;
+            destination[2] = TimeStamp_2;
+            destination[3] = TimeStamp_3;
+            destination[4] = TimeStamp_4;
+            destination[5] = TimeStamp_5;
+            destination[6] = Randomness_0;
+            destination[7] = Randomness_1;
+            destination[8] = Randomness_2;
+            destination[9] = Randomness_3;
+            destination[10] = Randomness_4;
+            destination[11] = Randomness_5;
+            destination[12] = Randomness_6;
+            destination[13] = Randomness_7;
+            destination[14] = Randomness_8;
+            destination[15] = Randomness_9;
+
+            return true;
         }
 
         public bool Equals(Ulid other)
@@ -416,7 +430,7 @@ namespace CSharp.Ulid
             return false;
         }
 
-        public static explicit operator byte[] (Ulid ulid)
+        public static explicit operator byte[](Ulid ulid)
         {
             return ulid.ToByteArray();
         }

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 C# .NET Standard 2.0 port of [alizain/ulid](https://github.com/alizain/ulid)
 
+![CI](https://github.com/mcb2001/CSharp.Ulid/workflows/CI/badge.svg)
+
 ## Usage
 
-```
+```c#
 using CSharp.Ulid;
 
 internal class Program
@@ -39,6 +41,8 @@ internal class Program
 
         Ulid ulidFromBytes = new Ulid(new byte[] { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
 
+        Ulid ulidFromReadOnlySpan = new Ulid(new ReadOnlySpan<byte>(new byte[] { 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+
         Ulid.TryParse("00000000000000000000000000", out Ulid ulitParsed);
 
         Ulid ulidDefault = default(Ulid);
@@ -46,6 +50,10 @@ internal class Program
         byte[] byteExplicit = (byte[])new Ulid();
 
         byte[] byteFromMethod = new Ulid().ToByteArray();
+
+        Span<byte> storage = stackalloc byte[100];
+        Span<byte> slicedSpan = storage.Slice(start: 55, length: 30);
+        Ulid.NewUlid().TryWriteBytes(slicedSpan); // if true, we should get 16-bytes of Ulid bytes written in `storage` starting at index 55.
 
         string stringRepresentation = new Ulid().ToString();
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk":{
+    "version":"5.0.100",
+    "rollForward":"latestMajor"
+  }
+}


### PR DESCRIPTION
This PR attempts to match `System.Guid` API parity.

* Add `ctor(ReadOnlySpan<byte>)`.
* Add `TryWriteBytes(Span<byte>)`.
* Add unit tests for binary data.
* Add netstandard2.1, where spanified APIs are available OOTB.
  * Keep netstandard2.0, and add `System.Memory` dependency for this TFM.

Additionally:

* Update unit test project to net5.0.
* Add GitHub Actions CI script.
  * Sample CI run: https://github.com/am11/CSharp.Ulid/runs/1407025549?check_suite_focus=true
* Add global.json, to assist CI toolset, which is still using 3.1, to acquire 5.0 SDK (idempotently).
* Update README with CI badge and new APIs usage in sample code.