### PR TITLE
Avoid string mutation on .NET Standard 2.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,10 +27,12 @@ jobs:
           echo "BRANCH_OR_TAG=$BRANCH_OR_TAG" >> $GITHUB_ENV
           git clone --single-branch --branch $BRANCH_OR_TAG --depth 1 https://${{ secrets.CLONE_TOKEN }}:x-oauth-basic@github.com/$REPO.git .
 
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.100
+          dotnet-version: |
+            3.1.x
+            7.0.x
 
       - name: Build
         run: dotnet build --configuration Release

--- a/CSharp.Ulid.Tests/CSharp.Ulid.Tests.csproj
+++ b/CSharp.Ulid.Tests/CSharp.Ulid.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0;netcoreapp3.1;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/CSharp.Ulid/StringExtensions.cs
+++ b/CSharp.Ulid/StringExtensions.cs
@@ -16,17 +16,9 @@ namespace CSharp.Ulid
             if (action is null) throw new ArgumentNullException(nameof(action));
             if (length == 0) return string.Empty;
 
-            unsafe
-            {
-                var str = new string('\0', length);
-                fixed (char* chars = str)
-                {
-                    var span = new Span<char>(chars, length);
-                    action(span, state);
-                }
-
-                return str;
-            }
+            var chars = new char[length];
+            action(chars, state);
+            return new string(chars);
 #else
             return string.Create(length, state, action);
 #endif

--- a/CSharp.Ulid/StringExtensions.cs
+++ b/CSharp.Ulid/StringExtensions.cs
@@ -2,6 +2,8 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
 
+#if NETSTANDARD2_0_OR_GREATER
+
 namespace CSharp.Ulid
 {
     internal static class StringExtensions
@@ -11,7 +13,6 @@ namespace CSharp.Ulid
 #endif
         public static string Create<TState>(int length, TState state, SpanAction<char, TState> action)
         {
-#if NETSTANDARD2_0
             if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
             if (action is null) throw new ArgumentNullException(nameof(action));
             if (length == 0) return string.Empty;
@@ -19,9 +20,8 @@ namespace CSharp.Ulid
             var chars = new char[length];
             action(chars, state);
             return new string(chars);
-#else
-            return string.Create(length, state, action);
-#endif
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Mutating strings is undefined behavior and should never be done. This PR changes the .NET Standard 2.0 implementation of `StringExtensions.Create` to create an array, act on it and then create the string from the array. There will be an extra allocation and copy but correctness is more important than performance.